### PR TITLE
Update Beta Tester Manual and add Detailed Installation Guides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.22.35] - 2026-02-28
+## [0.22.35] - 2026-03-02
+### Added
+- **Documentation**: Added comprehensive, step-by-step installation guides for beta testers in English and Polish (`website/docs/installation.md`, `website/docs/installation_pl.md`).
+- **Website UI**: Enhanced the testing portal (`website/index.html`) with a new "Step-by-Step Installation" section and direct links to the new guides.
+
+### Changed
+- **Tester Manual**: Updated `docs/TESTER_MANUAL.md` (and the website version) to reflect the new PyApp-based installation workflow, including security bypass instructions for Windows and macOS.
+- **Documentation**: Unified binary naming patterns across all guides to use version placeholders (e.g., `opendata-<system>-pyapp-<version>`).
+
 ### Fixed
+- **Documentation**: Corrected the default application port from `8000` to `8080` in all manuals.
+- **Documentation**: Fixed a typo in the Polish installation guide ("adreres" -> "adresem").
 - **Cross-Platform Path Handling**: Fixed `test_lazy_scanner_no_reads` failure on macOS and Windows caused by `Path.relative_to()` errors with symlinks and short paths (e.g., `/var` vs `/private/var`, `runneradmin` vs `RUNNER~1`). Both file path and root are now resolved before computing relative paths in `scan_project_lazy` and `format_file_list`.
 
 ### Testing

--- a/docs/TESTER_MANUAL.md
+++ b/docs/TESTER_MANUAL.md
@@ -1,8 +1,8 @@
 # OpenData Tool - Beta Tester Manual
 
-**Version:** v0.22.22
+**Version:** v0.22.35
 **Status:** Alpha (Active Development)
-**Target Audience:** Domain Scientists (Physics, Medical Physics) & Research Data Stewards
+**Target Audience:** Domain Scientists (Physics, Materials Science, Medical Physics) & Research Data Stewards
 
 ---
 
@@ -26,13 +26,21 @@ The **OpenData Tool** is an AI-powered assistant designed to "read" your researc
 - **Access:** You must be whitelisted for the internal testing team. Contact `Pawel T. Jochym` if you cannot sign in.
 
 ### Step-by-Step Launch
-1. **Download:** Get the latest binary for your OS from the [Testing Portal](website/index.html) or your distribution source.
-2. **Run:** Double-click the executable (`opendata-win.exe`, `opendata-linux`, or `.dmg`).
-   - *Note:* On Windows/Mac, you may need to "Run Anyway" if the app is unsigned.
-3. **System Tray Icon:** A small icon will appear in your system tray (bottom-right on Windows, top-right on Mac/Linux). 
-   - **Open Dashboard:** Opens the main interface in your default browser.
-   - **Exit:** Stops the server and exits.
-4. **Browser Dashboard:** The main interface will open automatically in your default web browser (usually `http://localhost:8000`).
+1. **Download:** Get the latest binary for your OS from the [Testing Portal](https://jochym.github.io/opendata/).
+   Files follow the pattern: `opendata-<system>-pyapp-<version>`.
+   - **Windows:** `opendata-win-pyapp-<version>.exe`
+   - **macOS:** `opendata-macos-arm-pyapp-<version>` (M1/M2/M3) or `opendata-macos-intel-pyapp-<version>` (Intel)
+   - **Linux:** `opendata-linux-pyapp-<version>`
+2. **Run & Security Bypass:**
+   - **Windows:** Double-click the file. If a "Windows protected your PC" (SmartScreen) warning appears, click **"More info"** then **"Run anyway"**.
+   - **macOS:** **Right-click** the file and select **Open** to bypass the "Unidentified Developer" warning. Alternatively, go to *System Settings -> Privacy & Security* and click **"Open Anyway"**.
+   - **Linux:** Run `chmod +x <filename>` then execute it. Ensure `libfuse2` is installed on your system (common on Ubuntu/Debian).
+3. **The "First Launch" Delay:** 
+   - ⏳ **Important:** On the very first run, the tool may take **up to 60 seconds** to start. It is silently unpacking its environment. Please be patient; subsequent launches will be near-instant.
+4. **System Tray Interaction:**
+   - Once started, a small OpenData Tool icon will appear in your **System Tray** (near the clock).
+   - **Right-click** the icon and select **"Open Dashboard"** to open the interface in your browser.
+   - The interface usually opens at `http://localhost:8080`.
 
 ---
 

--- a/website/docs/installation.md
+++ b/website/docs/installation.md
@@ -1,0 +1,61 @@
+# Installation Guide for Beta Testers
+
+Welcome to the OpenData Tool testing program! This guide will walk you through the process of running the tool on your computer. The tool is prepared so that it **does not require installing Python** or any complex libraries. Everything you need is in a single file.
+
+Note: All binary files follow the naming pattern: `opendata-<platform>-pyapp-<version>`.
+
+---
+
+## 🪟 Windows (10 / 11)
+
+1. **Download:** Get the `opendata-win-pyapp-<version>.exe` file from the portal.
+2. **Run:** Double-click the downloaded file.
+3. **SmartScreen Warning:** Since the program is in early testing and doesn't have a digital certificate yet, Windows may show a "Windows protected your PC" window.
+   - Click **"More info"**.
+   - Click the **"Run anyway"** button.
+4. **First Launch:** On the first run, the program may need 30 to 60 seconds to prepare its working environment. Please be patient – subsequent launches will be near-instant.
+5. **How to check if it's working?** A small OpenData Tool icon will appear in your system tray (near the clock). Right-click it and select **"Open Dashboard"** to open the interface in your browser.
+
+---
+
+## 🍎 macOS (Intel and M1/M2/M3)
+
+1. **Download the correct version:**
+   - If you have an Apple Silicon processor (M1, M2, M3): choose `opendata-macos-arm-pyapp-<version>`.
+   - If you have an older Intel processor: choose `opendata-macos-intel-pyapp-<version>`.
+2. **Running (Bypassing security):** Apple is strict about apps from outside the App Store. You will see a message that the app is from an "unidentified developer".
+   - **Method 1:** **Right-click** the file and select **Open**. A dialog will appear with an "Open" button that isn't there with a normal click.
+   - **Method 2:** Go to *System Settings -> Privacy & Security*. Scroll down and click the **"Open Anyway"** button next to the program name.
+3. **Permissions:** The program may ask for access to your "Downloads" folder or other locations you choose for analysis. Please accept these requests.
+
+---
+
+## 🐧 Linux (Ubuntu, Debian, Fedora, etc.)
+
+1. **Download:** Get the `opendata-linux-pyapp-<version>` file.
+2. **Grant Permissions:** After downloading, the file must be made "executable".
+   - **GUI:** Right-click the file -> *Properties* -> *Permissions* -> Check **"Allow executing file as program"**.
+   - **Terminal:** `chmod +x opendata-linux-pyapp-*`
+3. **Run:** Double-click or type `./opendata-linux-pyapp-*` in the terminal.
+4. **Dependencies:** The program is almost entirely self-sufficient, but on very "slim" Linux versions, you might need `libfuse2` or standard C libraries. If the program doesn't start, check the terminal logs.
+
+---
+
+## 💡 Good to Know (Potential Issues)
+
+### ⏳ First Launch is a "Silent Installation"
+The **PyApp** technology we use performs an automatic configuration of your working environment on the first run (it creates a "virtual environment").
+- **Be Patient:** During the first launch, the program window (or tray icon) may appear with a significant delay (up to a minute). The system is unpacking hundreds of files needed for the AI tools.
+- **Disk Space:** The program takes about 300-500 MB after unpacking in your home folder (usually in `.cache/pyapp` or similar).
+- **Internet:** Although most files are in the package, we recommend an internet connection for the first launch so the program can verify the installation.
+
+### 🌐 Browser Interface
+OpenData Tool runs as a background server. The user interface opens in your default browser at `http://localhost:8080`.
+- If the browser window doesn't open automatically, try entering this address manually.
+- The program does not send your research data to the server without your consent (AI only needs to send text fragments for analysis after you sign in).
+
+### 🛠️ Where to Get Help?
+If the program freezes or won't start:
+1. Check if the system tray icon (near the clock) is active.
+2. Try closing the program (Exit in the icon menu) and restart it.
+3. If the error persists, send us information at `jochym@ifj.edu.pl`, including (if possible) a screenshot of the error.

--- a/website/docs/installation_pl.md
+++ b/website/docs/installation_pl.md
@@ -1,0 +1,64 @@
+# Instrukcja Instalacji OpenData Tool dla Testerów
+
+Witaj w programie testów OpenData Tool! Ta instrukcja przeprowadzi Cię przez proces uruchomienia narzędzia na Twoim komputerze. Narzędzie zostało przygotowane tak, aby **nie wymagało instalacji Pythona** ani żadnych skomplikowanych bibliotek. Wszystko, czego potrzebujesz, znajduje się w jednym pliku.
+
+Uwaga: Wszystkie pliki binarne podążają za wzorem nazwy: `opendata-<platforma>-pyapp-<wersja>`.
+
+---
+
+## 🪟 Windows (10 / 11)
+
+1. **Pobierz:** Ściągnij plik `opendata-win-pyapp-<wersja>.exe` z portalu testowego.
+2. **Uruchom:** Kliknij dwukrotnie na pobrany plik.
+3. **Ostrzeżenie SmartScreen:** Ponieważ program jest w fazie wczesnych testów i nie posiada jeszcze certyfikatu cyfrowego, Windows może wyświetlić niebieskie okno "Windows protected your PC" (System Windows ochronił ten komputer).
+   - Kliknij napis **"More info"** (Więcej informacji).
+   - Kliknij przycisk **"Run anyway"** (Uruchom mimo to).
+4. **Pierwsze uruchomienie:** Przy pierwszym włączeniu program może potrzebować od 30 do 60 sekund na przygotowanie środowiska pracy. Prosimy o cierpliwość – kolejne uruchomienia będą błyskawiczne.
+5. **Jak sprawdzić czy działa?** Na pasku zadań (koło zegara) pojawi się mała ikona OpenData Tool. Kliknij ją prawym przyciskiem myszy i wybierz **"Open Dashboard"**, aby otworzyć interfejs w przeglądarce.
+
+---
+
+## 🍎 macOS (Intel oraz M1/M2/M3)
+
+1. **Pobierz właściwą wersję:**
+   - Jeśli masz procesor Apple Silicon (M1, M2, M3): wybierz `opendata-macos-arm-pyapp-<wersja>`.
+   - Jeśli masz starszy procesor Intel: wybierz `opendata-macos-intel-pyapp-<wersja>`.
+2. **Uruchomienie (Omijanie zabezpieczeń):** Apple rygorystycznie podchodzi do aplikacji spoza App Store. Przy próbie otwarcia zobaczysz komunikat, że aplikacja pochodzi od "nieznanego dewelopera".
+   - **Metoda 1:** Kliknij na plik **prawym przyciskiem myszy** i wybierz **Otwórz** (Open). Wtedy w oknie dialogowym pojawi się przycisk "Otwórz", którego nie ma przy zwykłym kliknięciu.
+   - **Metoda 2:** Wejdź w *Ustawienia Systemowe -> Prywatność i bezpieczeństwo*. Zjedź na dół i kliknij przycisk **"Open Anyway"** (Otwórz mimo to) przy nazwie programu.
+3. **Uprawnienia:** Program może poprosić o dostęp do plików w folderze "Pobrane" lub innych lokalizacjach, które wskażesz do analizy. Zaakceptuj te prośby.
+
+---
+
+## 🐧 Linux (Ubuntu, Debian, Fedora, itp.)
+
+1. **Pobierz:** Ściągnij plik `opendata-linux-pyapp-<wersja>`.
+2. **Nadaj uprawnienia:** Po pobraniu plik musi stać się "wykonywalny".
+   - **Graficznie:** Kliknij prawym na plik -> *Właściwości* -> *Uprawnienia* -> Zaznacz **"Zezwól na wykonywanie pliku jako programu"**.
+   - **Terminalowo:** `chmod +x opendata-linux-pyapp-*`
+3. **Uruchom:** Kliknij dwukrotnie lub wpisz w terminalu `./opendata-linux-pyapp-*`.
+4. **Zależności:** Program jest niemal w pełni samowystarczalny, ale na bardzo "odchudzonych" wersjach Linuxa może brakować biblioteki `libfuse2` lub standardowych bibliotek C. Jeśli program się nie uruchamia, sprawdź logi w terminalu.
+
+---
+
+## 💡 Co warto wiedzieć (Potencjalne problemy)
+
+### ⏳ Pierwszy start to "Cicha Instalacja"
+Technologia **PyApp**, której używamy, przy pierwszym uruchomieniu wykonuje automatyczną konfigurację Twojego środowiska pracy (tworzy tzw. wirtualne środowisko). 
+- **Bądź cierpliwy:** Podczas pierwszego uruchomienia okno programu (lub ikona w zasobniku) może pojawić się z dużym opóźnieniem (nawet do minuty). System w tym czasie wypakowuje setki plików potrzebnych do działania narzędzi AI.
+- **Dysk twardy:** Program zajmuje około 300-500 MB po wypakowaniu w Twoim folderze domowym (katalog `.cache/pyapp` lub podobny).
+- **Internet:** Mimo że większość plików jest w pakiecie, przy pierwszym starcie zalecamy połączenie z internetem, aby program mógł zweryfikować poprawność instalacji.
+
+### 🌐 Interfejs w przeglądarce
+OpenData Tool działa jako serwer w tle. Interfejs użytkownika otwiera się w Twojej domyślnej przeglądarce pod adresem `http://localhost:8080`. 
+- Jeśli okno przeglądarki się nie otworzy automatycznie, spróbuj wpisać ten adres ręcznie.
+- Program nie wysyła Twoich danych badawczych na serwer bez Twojej zgody (AI potrzebuje wysłać tylko fragmenty tekstu do analizy po Twoim zalogowaniu).
+
+### 🛠️ Gdzie szukać pomocy?
+Jeśli program się zawiesi lub nie chce się uruchomić:
+1. Sprawdź, czy ikona w zasobniku systemowym (koło zegara) jest aktywna.
+2. Spróbuj zamknąć program (Exit w menu ikony) i uruchomić go ponownie.
+3. Jeśli błąd się powtarza, wyślij nam informację na adres `jochym@ifj.edu.pl`, dołączając (jeśli to możliwe) zrzut ekranu z ewentualnym błędem.
+
+---
+*Dziękujemy za pomoc w testowaniu OpenData Tool! Twoje uwagi są dla nas bezcenne.*

--- a/website/docs/tester.md
+++ b/website/docs/tester.md
@@ -1,8 +1,8 @@
 # OpenData Tool - Beta Tester Manual
 
-**Version:** v0.22.22
+**Version:** v0.22.35
 **Status:** Alpha (Active Development)
-**Target Audience:** Domain Scientists (Physics, Medical Physics) & Research Data Stewards
+**Target Audience:** Domain Scientists (Physics, Materials Science, Medical Physics) & Research Data Stewards
 
 ---
 
@@ -26,13 +26,21 @@ The **OpenData Tool** is an AI-powered assistant designed to "read" your researc
 - **Access:** You must be whitelisted for the internal testing team. Contact `Pawel T. Jochym` if you cannot sign in.
 
 ### Step-by-Step Launch
-1. **Download:** Get the latest binary for your OS from the [Testing Portal](website/index.html) or your distribution source.
-2. **Run:** Double-click the executable (`opendata-win.exe`, `opendata-linux`, or `.dmg`).
-   - *Note:* On Windows/Mac, you may need to "Run Anyway" if the app is unsigned.
-3. **System Tray Icon:** A small icon will appear in your system tray (bottom-right on Windows, top-right on Mac/Linux). 
-   - **Open Dashboard:** Opens the main interface in your default browser.
-   - **Exit:** Stops the server and exits.
-4. **Browser Dashboard:** The main interface will open automatically in your default web browser (usually `http://localhost:8000`).
+1. **Download:** Get the latest binary for your OS from the [Testing Portal](https://jochym.github.io/opendata/).
+   Files follow the pattern: `opendata-<system>-pyapp-<version>`.
+   - **Windows:** `opendata-win-pyapp-<version>.exe`
+   - **macOS:** `opendata-macos-arm-pyapp-<version>` (M1/M2/M3) or `opendata-macos-intel-pyapp-<version>` (Intel)
+   - **Linux:** `opendata-linux-pyapp-<version>`
+2. **Run & Security Bypass:**
+   - **Windows:** Double-click the file. If a "Windows protected your PC" (SmartScreen) warning appears, click **"More info"** then **"Run anyway"**.
+   - **macOS:** **Right-click** the file and select **Open** to bypass the "Unidentified Developer" warning. Alternatively, go to *System Settings -> Privacy & Security* and click **"Open Anyway"**.
+   - **Linux:** Run `chmod +x <filename>` then execute it. Ensure `libfuse2` is installed on your system (common on Ubuntu/Debian).
+3. **The "First Launch" Delay:** 
+   - ⏳ **Important:** On the very first run, the tool may take **up to 60 seconds** to start. It is silently unpacking its environment. Please be patient; subsequent launches will be near-instant.
+4. **System Tray Interaction:**
+   - Once started, a small OpenData Tool icon will appear in your **System Tray** (near the clock).
+   - **Right-click** the icon and select **"Open Dashboard"** to open the interface in your browser.
+   - The interface usually opens at `http://localhost:8080`.
 
 ---
 

--- a/website/index.html
+++ b/website/index.html
@@ -73,6 +73,9 @@
                 <button onclick="loadDoc('tester')" class="bg-white/10 backdrop-blur-md border border-white/30 px-8 py-4 rounded-xl font-bold hover:bg-white/20 transition-all shadow-lg flex items-center">
                     <i class="fas fa-vial mr-3 text-yellow-400"></i> TESTER MANUAL
                 </button>
+                <button onclick="loadDoc('installation')" class="bg-white/10 backdrop-blur-md border border-white/30 px-8 py-4 rounded-xl font-bold hover:bg-white/20 transition-all shadow-lg flex items-center">
+                    <i class="fas fa-book-open mr-3 text-emerald-400"></i> INSTALLATION GUIDE
+                </button>
                 <button onclick="loadDoc('developer')" class="bg-white/10 backdrop-blur-md border border-white/30 px-8 py-4 rounded-xl font-bold hover:bg-white/20 transition-all shadow-lg flex items-center">
                     <i class="fas fa-code mr-3 text-blue-400"></i> DEVELOPER GUIDE
                 </button>
@@ -315,6 +318,65 @@
                     <span class="text-sm text-slate-400 mt-2 font-mono">x86_64</span>
                 </a>
             </div>
+
+            <!-- Detailed Installation Guide Section -->
+            <div class="mt-20">
+                <div class="flex items-center justify-center mb-10 gap-4">
+                    <div class="h-1 w-12 bg-emerald-500 rounded-full"></div>
+                    <h3 class="text-2xl font-black text-slate-900 uppercase tracking-tight">Step-by-Step Installation</h3>
+                    <div class="h-1 w-12 bg-emerald-500 rounded-full"></div>
+                </div>
+                
+                <div class="grid md:grid-cols-3 gap-8">
+                    <div class="bg-white p-8 rounded-[2rem] border border-slate-100 shadow-xl">
+                        <div class="flex items-center mb-6">
+                            <i class="fab fa-windows text-blue-600 text-3xl mr-4"></i>
+                            <h4 class="font-bold text-xl">Windows Guide</h4>
+                        </div>
+                        <ul class="space-y-4 text-sm text-slate-600">
+                            <li class="flex items-start"><span class="bg-blue-100 text-blue-700 w-6 h-6 rounded-full flex items-center justify-center mr-3 flex-shrink-0 font-bold">1</span> Run the <code>opendata-win-pyapp-&lt;version&gt;.exe</code> file.</li>
+                            <li class="flex items-start"><span class="bg-blue-100 text-blue-700 w-6 h-6 rounded-full flex items-center justify-center mr-3 flex-shrink-0 font-bold">2</span> Click <strong>"More info"</strong> and <strong>"Run anyway"</strong> on the SmartScreen warning.</li>
+                            <li class="flex items-start"><span class="bg-blue-100 text-blue-700 w-6 h-6 rounded-full flex items-center justify-center mr-3 flex-shrink-0 font-bold">3</span> Wait ~60s for the first-time setup.</li>
+                            <li class="flex items-start"><span class="bg-blue-100 text-blue-700 w-6 h-6 rounded-full flex items-center justify-center mr-3 flex-shrink-0 font-bold">4</span> Look for the icon in your system tray to open the Dashboard.</li>
+                        </ul>
+                    </div>
+                    
+                    <div class="bg-white p-8 rounded-[2rem] border border-slate-100 shadow-xl">
+                        <div class="flex items-center mb-6">
+                            <i class="fab fa-apple text-slate-900 text-3xl mr-4"></i>
+                            <h4 class="font-bold text-xl">macOS Guide</h4>
+                        </div>
+                        <ul class="space-y-4 text-sm text-slate-600">
+                            <li class="flex items-start"><span class="bg-slate-200 text-slate-800 w-6 h-6 rounded-full flex items-center justify-center mr-3 flex-shrink-0 font-bold">1</span> Download the correct architecture (ARM for M1/M2, Intel for old Macs).</li>
+                            <li class="flex items-start"><span class="bg-slate-200 text-slate-800 w-6 h-6 rounded-full flex items-center justify-center mr-3 flex-shrink-0 font-bold">2</span> <strong>Right-click</strong> the file and select <strong>"Open"</strong> to bypass security warnings.</li>
+                            <li class="flex items-start"><span class="bg-slate-200 text-slate-800 w-6 h-6 rounded-full flex items-center justify-center mr-3 flex-shrink-0 font-bold">3</span> Wait ~60s for the first-time setup (unpacking).</li>
+                            <li class="flex items-start"><span class="bg-slate-200 text-slate-800 w-6 h-6 rounded-full flex items-center justify-center mr-3 flex-shrink-0 font-bold">4</span> Alternatively, allow it in <em>System Settings > Privacy & Security</em>.</li>
+                        </ul>
+                    </div>
+                    
+                    <div class="bg-white p-8 rounded-[2rem] border border-slate-100 shadow-xl">
+                        <div class="flex items-center mb-6">
+                            <i class="fab fa-linux text-orange-600 text-3xl mr-4"></i>
+                            <h4 class="font-bold text-xl">Linux Guide</h4>
+                        </div>
+                        <ul class="space-y-4 text-sm text-slate-600">
+                            <li class="flex items-start"><span class="bg-orange-100 text-orange-700 w-6 h-6 rounded-full flex items-center justify-center mr-3 flex-shrink-0 font-bold">1</span> Download the universal binary <code>opendata-linux-pyapp-&lt;version&gt;</code>.</li>
+                            <li class="flex items-start"><span class="bg-orange-100 text-orange-700 w-6 h-6 rounded-full flex items-center justify-center mr-3 flex-shrink-0 font-bold">2</span> Run <code>chmod +x opendata-linux-pyapp-*</code> in your terminal.</li>
+                            <li class="flex items-start"><span class="bg-orange-100 text-orange-700 w-6 h-6 rounded-full flex items-center justify-center mr-3 flex-shrink-0 font-bold">3</span> Wait ~60s for the first-time setup. Ensure <code>libfuse2</code> is installed.</li>
+                        </ul>
+                    </div>
+                </div>
+                
+                <div class="mt-8 text-center">
+                    <button onclick="loadDoc('installation')" class="inline-flex items-center text-emerald-600 font-bold hover:underline">
+                        <i class="fas fa-plus-circle mr-2"></i> Read the full Installation FAQ & Troubleshooting
+                    </button>
+                    <span class="mx-4 text-slate-300">|</span>
+                    <button onclick="loadDoc('installation_pl')" class="inline-flex items-center text-blue-600 font-bold hover:underline">
+                        <i class="fas fa-flag mr-2"></i> Przeczytaj instrukcję po polsku
+                    </button>
+                </div>
+            </div>
             
             <!-- Development Installation -->
             <div class="mt-16 bg-slate-50 p-10 rounded-[2.5rem] border border-slate-200">
@@ -384,6 +446,8 @@
             loading.classList.remove('hidden');
             
             if (type === 'tester') docTitle.innerText = 'Beta Tester Manual';
+            else if (type === 'installation') docTitle.innerText = 'Installation Guide';
+            else if (type === 'installation_pl') docTitle.innerText = 'Instrukcja Instalacji (PL)';
             else if (type === 'developer') docTitle.innerText = 'Developer Guide';
             else docTitle.innerText = 'Binary Build System';
             


### PR DESCRIPTION
## Summary
- Updated `TESTER_MANUAL.md` (and website version) to reflect the new PyApp installation workflow.
- Added detailed step-by-step installation guides in English and Polish (`website/docs/installation.md`, `website/docs/installation_pl.md`).
- Enhanced `website/index.html` with a quick-start guide and direct links to the new documentation.
- Version bumped to v0.22.35 in documentation.

## Details
- Documented SmartScreen (Windows) and Unidentified Developer (macOS) bypasses.
- Added a critical warning about the ~60s delay during the first launch (silent unpacking).
- Included Linux dependency information (libfuse2).